### PR TITLE
fix comment symbols

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "##",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "blockComment": [ "<%doc>", "</%doc>" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
This support `ctrl + /` to toggle comments in mako http://docs.makotemplates.org/en/latest/syntax.html#comments